### PR TITLE
[feature] 게임 상태 초기화 메서드 추가 및 UI 연결성 확보를 위한 movePiece 메서드의 리턴 타입 변경

### DIFF
--- a/src/Model/GameModel.java
+++ b/src/Model/GameModel.java
@@ -40,7 +40,7 @@ public class GameModel {
         this.players = new Player[numPlayers];
         this.gameScores = new int[numPlayers];
         for (int i = 0; i < numPlayers; i++) {
-            players[i] = new Player("Player" + i, numPieces);
+            players[i] = new Player("Player" + (i+1), numPieces);
         }
         for (int i = 0; i < numPlayers; i++) {
             gameScores[i] = 0;
@@ -85,11 +85,28 @@ public class GameModel {
 
     /// methods ///
 
-    /// Controller 또는 View에서 호출하는 메서드 -> game state 변경
-    public void movePiece(MovablePiece selectedPiece, Position selectedPosition) {
-        Piece targetPositionPiece = findPositionPieceAt(selectedPosition);
+    // 게임 상태 초기화 //
+    public boolean initializeGame() { // try catch로 예외 처리를 해야하지만 생략, 항상 true를 반환
+        for (int i = 0; i < numberOfPlayers; i++) {
+            players[i] = new Player("Player" + (i+1), numberOfPieces);
+        }
+        for (int i = 0; i < players.length; i++) {
+            gameScores[i] = 0;
+        }
+        yutResultArrayDeque.clear(); // 윷 결과 초기화
+        positionPieceArrayDeque.clear(); // 위치 조각 초기화
+        currentPlayerIndex = 0; // 현재 플레이어 인덱스 초기화
+        extraTurnCount = 0; // 추가 턴 수 초기화
+        return true; // 게임 초기화 성공
+    }
 
-        if (groupPiecesAtPosition(selectedPiece, selectedPosition)) return; // 경로를 target이 이미 저장하고 있으므로
+    /// Controller 또는 View에서 호출하는 메서드 -> game state 변경
+    public boolean movePiece(MovablePiece selectedPiece, Position selectedPosition) {
+        Piece targetPositionPiece = findPositionPieceAt(selectedPosition);
+        if (selectedPiece.isArrived()) return false; // 이미 도착한 말은 이동할 수 없음
+        if (targetPositionPiece == null) return false; // 해당 위치로 이동할 수 없음
+
+        if (groupPiecesAtPosition(selectedPiece, selectedPosition)) return true; // 경로를 target이 이미 저장하고 있으므로
         if (captureOpponentPiece(selectedPiece, selectedPosition)) extraTurnCount++;
 
         int targetSize;
@@ -108,6 +125,8 @@ public class GameModel {
         // 사용한 윷 제거
         YutResult yutResult = yut.throwYut(targetSize);
         yutResultArrayDeque.removeFirstOccurrence(yutResult);
+
+        return true;
     }
 
     public ArrayDeque<Position> getPosableMoves(ArrayDeque<YutResult> YutResultArrayDeque) {

--- a/src/Model/MovablePiece.java
+++ b/src/Model/MovablePiece.java
@@ -42,6 +42,7 @@ public class MovablePiece {
         if (pieceArrayDeque.peekFirst() != null) {
             currentPosition = pieceArrayDeque.peekFirst().getCurrentPosition(); // 그룹의 첫 번째 말의 위치로 업데이트
         }
+        isArrived();
     }
 
     public boolean isArrived() {

--- a/src/Model/Piece.java
+++ b/src/Model/Piece.java
@@ -27,6 +27,10 @@ public class Piece {
     public void moveTo(int n) {
         if (n < 0) {
             moveBackward(); // 음수일 경우 뒤로 한 칸 이동
+        } else if (n == 0) {
+            currentPosition = new Position("START"); // 현재 위치를 START로 초기화
+            recentPath.clear();
+            recentPath.add(currentPosition); // START 위치 추가
         } else {
             moveForward(n);
         }


### PR DESCRIPTION
## 📌 개요 (Summary)

GameModel 클레스에서 게임 상태 초기화 메서드를 구현하고 movePiece 메서드에서 말이 선택된 위치로 이동할 수 있는 지를 boolean으로 반환하도록 적용했습니다.

## 🔍 변경 사항 (Changes)

- [ ] feat:
    - moveTo(0) 일때 START 위치로 초기화 하도록 개발자, 테스트용 케이스 추가
    - 게임 상태 초기화를 위한 initializeGame 메서드 추가
- [ ] refactor:
    - `refactor` movePiece에서 selectedPosition으로 이동할 수 있는지를 boolean으로 반환하도록 수정

## 🧪 테스트 결과 (Test Results)

- [ ] 테스트되지않음
    - [ ] player 초기화를 각 Player에 new Player를 다시 할당하는 방식으로 사용했는데, 실제로 적용되는 지 테스트 필요

## 📎 관련 이슈 (Related Issue)

- 이슈 번호: `not issued`

