### PR TITLE
feat: JavaFX UI 완성 및 런처 구조 분리

### DIFF
--- a/src/data/config.txt
+++ b/src/data/config.txt
@@ -8,7 +8,7 @@ player:4
 piece:5
 
 # ui type [1-2] 1: swing, 2: javaFX
-ui:1
+ui:2
 
 # game mode [1-2] 1: normal, 2: test
 mode:2

--- a/src/main/Main.java
+++ b/src/main/Main.java
@@ -2,18 +2,29 @@ package main;
 
 import controller.GameController;
 import model.GameManager;
+import view.JavaFXLauncher;
 import view.SwingUI;
+import javafx.application.Application;
+import view.JavaFXLauncher;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.Scanner;
 
 public class Main {
     public static void main(String[] args) {
+        int uiType = UITypefromConfig();
+
         // 게임 모델과 컨트롤러 초기화
         GameManager model = new GameManager();
         GameController controller = new GameController(model);
         // Todo: UI를 위한 Interface를 구현하여 SwingUI와 GameController를 연결합니다.
-        SwingUI view = new SwingUI(controller, model);
-        controller.setView(view);
+        if(uiType ==1 ) {
 
-        // 게임 시작
+            SwingUI view = new SwingUI(controller, model);
+            controller.setView(view);
+
+            // 게임 시작
         /*while (true) {
             if (controller.resetGame()) {
                 System.out.println("reset이 눌린거여");
@@ -24,5 +35,29 @@ public class Main {
                 break;
             }
         }*/
+        } else if (uiType == 2) {
+            Application.launch(JavaFXLauncher.class, args);
+        } else {
+            System.out.println("잘못된 UI 타입입니다.");
+        }
+    }
+
+    private static int UITypefromConfig() {
+        try (Scanner scanner = new Scanner(new File("src/data/config.txt"))) {
+            while (scanner.hasNextLine()) {
+                String line = scanner.nextLine().trim();
+                if (line.startsWith("ui:")) {
+                    String[] parts = line.split(":");
+                    if (parts.length == 2) {
+                        return Integer.parseInt(parts[1].trim());
+                    }
+                }
+            }
+        } catch (FileNotFoundException e) {
+            System.err.println("config.txt 파일을 찾을 수 없습니다.");
+        } catch (NumberFormatException e) {
+            System.err.println("ui 타입 설정이 잘못되었습니다.");
+        }
+        return 1; // 기본값: Swing
     }
 }

--- a/src/view/JavaFXLauncher.java
+++ b/src/view/JavaFXLauncher.java
@@ -1,0 +1,19 @@
+// JavaFXLauncher.java
+package view;
+
+import controller.GameController;
+import javafx.application.Application;
+import javafx.stage.Stage;
+import model.GameManager;
+
+public class JavaFXLauncher extends Application {
+    @Override
+    public void start(Stage stage) {
+        GameManager model = new GameManager();
+        GameController controller = new GameController(model);
+        JavafxUI view = new JavafxUI(controller, model);
+        controller.setView(view);
+
+        view.start(stage); // JavaFXUI에서 Stage 시작
+    }
+}

--- a/src/view/JavafxUI.java
+++ b/src/view/JavafxUI.java
@@ -29,12 +29,13 @@ public class JavafxUI implements GameView {
     private ImageView turnImage;
     private ImageView yutImage;
 
-    // 버튼들 (아직 미구현)
+
+    // 버튼
     private Button throwButton;
     private Button STARTButton;
     private Button ENDButton;
 
-    private Map<String, Point2D> boardButtonPositions = new HashMap<>();
+    private Map<String, Point2D> piecePositions = new HashMap<>();
 
     private int numberOfPlayers; // 플레이어 수
     private int numberOfPieces; // 플레이어당 말 수
@@ -49,11 +50,16 @@ public class JavafxUI implements GameView {
 
 
     }
+    @Override
+    public void initUI() {
+        // JavaFX는 start(Stage)를 통해 UI를 시작하므로, 이 메서드는 실제로는 사용되지 않음
+    }
 
     // ------ UI 초기화: initUI() -> start() ------- //
     public void start(Stage stage) {
         this.stage = stage;
         root = new Pane();
+        root.setPrefSize(700, 700);
         Scene scene = new Scene(root, 700, 700);
 
         //일단 할당만해둠 추후에 이미지처리할예정
@@ -64,6 +70,13 @@ public class JavafxUI implements GameView {
         setupYutImage(); // 윷 이미지 초기화
         setupPlayerScoreImages(); // 플레이어 점수 이미지 초기화
         setupTurnImage(); // 현재 턴 이미지 초기화
+        createThrowButton();
+        setupStartButton();
+        setupEndButton();
+        createRestartButton();
+        createQuitButton();
+        setupCustomPopupButton();
+
 
         stage.setTitle("윷놀이 게임(JavaFX)"); //-> 일단 추후 이미지처리
         stage.setScene(scene);
@@ -73,22 +86,60 @@ public class JavafxUI implements GameView {
 
     // ------- 배경 설정 ------- //
     private void setupBackground() {
-        Image bgImage = new Image(getClass().getResourceAsStream("/data/ui/board/board_four.png"));
-        BackgroundImage background = new BackgroundImage(bgImage, BackgroundRepeat.NO_REPEAT, BackgroundRepeat.NO_REPEAT,
-                BackgroundPosition.DEFAULT, BackgroundSize.DEFAULT);
+        int boardSize = model.getSize(); // GameManager에서 보드 크기 가져오기
+        String imagePath;
+
+        switch (boardSize) {
+            case 4 -> imagePath = "/data/ui/board/board_four.png";
+            case 5 -> imagePath = "/data/ui/board/board_five.png";
+            case 6 -> imagePath = "/data/ui/board/board_six.png";
+            default -> {
+                System.out.println("Invalid board size");
+                imagePath = "/data/ui/board/board_four.png";
+            }
+        }
+
+        Image bgImage = new Image(Objects.requireNonNull(getClass().getResourceAsStream(imagePath)));
+        BackgroundImage background = new BackgroundImage(
+                bgImage,
+                BackgroundRepeat.NO_REPEAT,
+                BackgroundRepeat.NO_REPEAT,
+                BackgroundPosition.DEFAULT,
+                new BackgroundSize(700, 700, false, false, false, false)
+        );
         root.setBackground(new Background(background));
     }
 
+
     // ------ title 설정 ------ //
     private void setupTitleImage() {
-        //이미지 처리 / 위치 처리 필요
+        Image titleImg = new Image(Objects.requireNonNull(getClass().getResourceAsStream("/data/ui/title.PNG")));
+
+        titleImage = new ImageView(titleImg);
+
+        // 이미지 비율: 1242 x 558 → 1/6 축소
+        double originalWidth = 1242;
+        double originalHeight = 558;
+        double scaledWidth = originalWidth / 6;
+        double scaledHeight = originalHeight / 6;
+
+        titleImage.setFitWidth(scaledWidth);
+        titleImage.setFitHeight(scaledHeight);
+        titleImage.setPreserveRatio(true); // 혹시 비율 보정 원하면
+
+        // 좌표 위치 보정 (Swing과 동일한 방식)
+        titleImage.setLayoutX(475);
+        titleImage.setLayoutY(20);
+
+        // 보드 패널(root)에 추가
+        root.getChildren().add(titleImage);
     }
 
 
     // ------- Board 버튼 설정 -------- //
     private void setupBoardButtons() {
-        for (String id : boardButtonPositions.keySet()) {
-            Point2D point = boardButtonPositions.get(id);
+        for (String id : piecePositions.keySet()) {
+            Point2D point = piecePositions.get(id);
 
             Button nodeButton = new Button();
             nodeButton.setPrefSize(40, 40);
@@ -96,95 +147,348 @@ public class JavafxUI implements GameView {
             nodeButton.setLayoutY(point.getY());
             nodeButton.setOpacity(0); // 버튼 투명도 -> 0
 
-            nodeButton.setOnAction(e -> controller.handleBoardClick(id));
+            nodeButton.setId(id); // ✔ 버튼에 직접 ID를 부여
+
+            nodeButton.setOnAction(e -> {
+                String clickedId = ((Button) e.getSource()).getId(); // ✔ 이벤트에서 ID 직접 꺼냄
+                controller.handleBoardClick(clickedId);
+            });
 
             root.getChildren().add(nodeButton);
         }
     }
 
-    // ------ Player Score 설정 ------ // (아직 미구현)
 
-    // ------ START Button 설정 ------ // (아직 미구현)
+    // ------ Player Score 설정 ------ //
+    private void setupPlayerScoreImages() {
+        playerScoreImages = new ImageView[numberOfPlayers];
+        for (int i = 0; i < numberOfPlayers; i++) {
+            int playerNum = i + 1;
+            String imagePath = "/data/ui/score/player" + playerNum +
+                    "/player" + playerNum + "_" + numberOfPieces + ".png";
 
-    // ------ END Button 설정 ------ // (아직 미구현)
+            Image img = new Image(Objects.requireNonNull(getClass().getResourceAsStream(imagePath)));
 
-    // 추가 버튼들 (아직 미구현)
-
-
-
-
-
-
-
+            ImageView scoreView = new ImageView(img);
 
 
+            double scaledWidth = img.getWidth() / 3;
+            double scaledHeight = img.getHeight() / 3;
+
+            scoreView.setFitWidth(scaledWidth);
+            scoreView.setFitHeight(scaledHeight);
+
+            scoreView.setLayoutX(485);
+            scoreView.setLayoutY(181 + 47 * i);
 
 
-    // ---------- Board Buttons ---------- //
-    private void initBoardButtonPositions()
-    {
-        boardButtonPositions = new HashMap<>();
-        boardButtonPositions.put("P1", new Point2D(432-20, 353-20)); // 각 x, y의 20만큼 위치 보정
-        boardButtonPositions.put("P2", new Point2D(432-20, 275-20));
-        boardButtonPositions.put("P3", new Point2D(432-20, 197-20));
-        boardButtonPositions.put("P4", new Point2D(432-20, 119-20));
-        boardButtonPositions.put("P5", new Point2D(432-20, 42-20));
-
-        boardButtonPositions.put("P6", new Point2D(355-20, 42-20));
-        boardButtonPositions.put("P7", new Point2D(277-20, 42-20));
-        boardButtonPositions.put("P8", new Point2D(199-20, 42-20));
-        boardButtonPositions.put("P9", new Point2D(121-20, 42-20));
-        boardButtonPositions.put("P10", new Point2D(42-20, 42-20));
-
-        boardButtonPositions.put("P11", new Point2D(42-20, 119-20));
-        boardButtonPositions.put("P12", new Point2D(42-20, 197-20));
-        boardButtonPositions.put("P13", new Point2D(42-20, 275-20));
-        boardButtonPositions.put("P14", new Point2D(42-20, 353-20));
-        boardButtonPositions.put("P15", new Point2D(42-20, 432-20));
-
-        boardButtonPositions.put("P16", new Point2D(121-20, 432-20));
-        boardButtonPositions.put("P17", new Point2D(199-20, 432-20));
-        boardButtonPositions.put("P18", new Point2D(277-20, 432-20));
-        boardButtonPositions.put("P19", new Point2D(355-20, 432-20));
-        boardButtonPositions.put("P20", new Point2D(432-20, 432-20));
-
-        // 내부 경로
-        boardButtonPositions.put("E1", new Point2D(364-20, 108-20));
-        boardButtonPositions.put("E2", new Point2D(303-20, 171-20));
-        boardButtonPositions.put("E3", new Point2D(171-20, 303-20));
-        boardButtonPositions.put("E4", new Point2D(108-20, 364-20));
-
-        boardButtonPositions.put("C", new Point2D(237-20, 237-20));
-
-        boardButtonPositions.put("E5", new Point2D(108-20, 108-20));
-        boardButtonPositions.put("E6", new Point2D(171-20, 171-20));
-        boardButtonPositions.put("E7", new Point2D(303-20, 303-20));
-        boardButtonPositions.put("E8", new Point2D(364-20, 364-20));
+            root.getChildren().add(scoreView);
+            playerScoreImages[i] = scoreView;
+        }
     }
 
-    // 주요 메서드
+
+    // ------ START Button 설정 ------ //
+    private void setupStartButton() {
+        STARTButton = new Button();
+        STARTButton.setLayoutX(483); // 473 + 10 보정
+        STARTButton.setLayoutY(161);
+        STARTButton.setPrefSize(184, 202);
+        STARTButton.setStyle("-fx-background-color: transparent;");
+
+        // START 위치 클릭 시 controller로 전달
+        STARTButton.setOnAction(e -> {
+            controller.handleBoardClick("START");
+            System.out.println("START Button Clicked");
+        });
+
+        root.getChildren().add(STARTButton);
+    }
+
+    // ------ END Button 설정 ------ //
+    private void setupEndButton() {
+        ENDButton = new Button();
+        ENDButton.setLayoutX(20);      // Swing과 동일
+        ENDButton.setLayoutY(472);
+        ENDButton.setPrefSize(433, 207);  // 1299/3, 621/3
+        ENDButton.setStyle("-fx-background-color: transparent;");
+
+        ENDButton.setOnAction(e -> {
+            controller.handleBoardClick("END");
+            System.out.println("END Button Clicked");
+        });
+
+        root.getChildren().add(ENDButton);
+    }
+
+    // ------ Turn Image 설정 ------ //
+    private void setupTurnImage() {
+        int currentPlayer = model.getCurrentPlayerNumber(); // 보통 1부터 시작
+        String imagePath = "/data/ui/turn/turn_" + currentPlayer + ".png";
+        Image img = new Image(Objects.requireNonNull(getClass().getResourceAsStream(imagePath)));
+        double scaledWidth = img.getWidth() / 3;
+        double scaledHeight = img.getHeight() / 3;
+
+        turnImage = new ImageView(img);
+        turnImage.setFitWidth(scaledWidth);
+        turnImage.setFitHeight(scaledHeight);
+
+        turnImage.setLayoutX(485);
+        turnImage.setLayoutY(392);
+        root.getChildren().add(turnImage);
+    }
+
+    // ---------- Board Buttons ---------- //
+    private void initBoardButtonPositions() {
+        piecePositions = new HashMap<>();
+        int boardSize = model.getSize(); // 4, 5, 6
+
+        switch (boardSize) {
+            case 4 -> initBoardButtons4();
+            case 5 -> initBoardButtons5();
+            case 6 -> initBoardButtons6();
+            default -> {
+                System.out.println("Invalid board size.");
+                initBoardButtons4();
+            }
+        }
+    }
+    private void initBoardButtons4() {
+        piecePositions = new HashMap<>();
+        piecePositions.put("P1", new Point2D(432-20, 353-20)); // 각 x, y의 20만큼 위치 보정
+        piecePositions.put("P2", new Point2D(432-20, 275-20));
+        piecePositions.put("P3", new Point2D(432-20, 197-20));
+        piecePositions.put("P4", new Point2D(432-20, 119-20));
+        piecePositions.put("P5", new Point2D(432-20, 42-20));
+
+        piecePositions.put("P6", new Point2D(355-20, 42-20));
+        piecePositions.put("P7", new Point2D(277-20, 42-20));
+        piecePositions.put("P8", new Point2D(199-20, 42-20));
+        piecePositions.put("P9", new Point2D(121-20, 42-20));
+        piecePositions.put("P10", new Point2D(42-20, 42-20));
+
+        piecePositions.put("P11", new Point2D(42-20, 119-20));
+        piecePositions.put("P12", new Point2D(42-20, 197-20));
+        piecePositions.put("P13", new Point2D(42-20, 275-20));
+        piecePositions.put("P14", new Point2D(42-20, 353-20));
+        piecePositions.put("P15", new Point2D(42-20, 432-20));
+
+        piecePositions.put("P16", new Point2D(121-20, 432-20));
+        piecePositions.put("P17", new Point2D(199-20, 432-20));
+        piecePositions.put("P18", new Point2D(277-20, 432-20));
+        piecePositions.put("P19", new Point2D(355-20, 432-20));
+        piecePositions.put("P20", new Point2D(432-20, 432-20));
+
+        // 내부 경로
+        piecePositions.put("E1", new Point2D(364-20, 108-20));
+        piecePositions.put("E2", new Point2D(303-20, 171-20));
+        piecePositions.put("E3", new Point2D(171-20, 303-20));
+        piecePositions.put("E4", new Point2D(108-20, 364-20));
+
+        piecePositions.put("C", new Point2D(237-20, 237-20));
+
+        piecePositions.put("E5", new Point2D(108-20, 108-20));
+        piecePositions.put("E6", new Point2D(171-20, 171-20));
+        piecePositions.put("E7", new Point2D(303-20, 303-20));
+        piecePositions.put("E8", new Point2D(364-20, 364-20));
+    }
+
+    private void initBoardButtons5() {
+        piecePositions.put("P1", new Point2D(372-20, 375-20)); // 각 x, y의 20만큼 위치 보정
+        piecePositions.put("P2", new Point2D(388-20, 330-20));
+        piecePositions.put("P3", new Point2D(402-20, 284-20));
+        piecePositions.put("P4", new Point2D(417-20, 238-20));
+        piecePositions.put("P5", new Point2D(432-20, 192-20));
+
+        piecePositions.put("P6", new Point2D(393-20, 164-20));
+        piecePositions.put("P7", new Point2D(354-20, 135-20));
+        piecePositions.put("P8", new Point2D(315-20, 107-20));
+        piecePositions.put("P9", new Point2D(276-20, 78-20));
+        piecePositions.put("P10", new Point2D(236-20, 50-20));
+
+        piecePositions.put("P11", new Point2D(197-20, 78-20));
+        piecePositions.put("P12", new Point2D(158-20, 107-20));
+        piecePositions.put("P13", new Point2D(119-20, 135-20));
+        piecePositions.put("P14", new Point2D(80-20, 164-20));
+        piecePositions.put("P15", new Point2D(41-20, 192-20));
+
+        piecePositions.put("P16", new Point2D(56-20, 238-20));
+        piecePositions.put("P17", new Point2D(71-20, 284-20));
+        piecePositions.put("P18", new Point2D(87-20, 330-20));
+        piecePositions.put("P19", new Point2D(101-20, 375-20));
+        piecePositions.put("P20", new Point2D(115-20, 422-20));
+
+        piecePositions.put("P21", new Point2D(164-20, 422-20));
+        piecePositions.put("P22", new Point2D(212-20, 422-20));
+        piecePositions.put("P23", new Point2D(261-20, 422-20));
+        piecePositions.put("P24", new Point2D(309-20, 422-20));
+        piecePositions.put("P25", new Point2D(358-20, 422-20));
+
+        piecePositions.put("C", new Point2D(236-20, 255-20));
+
+        piecePositions.put("E1", new Point2D(354-20, 217-20));
+        piecePositions.put("E2", new Point2D(295-20, 236-20));
+        piecePositions.put("E3", new Point2D(200-20, 305-20));
+        piecePositions.put("E4", new Point2D(164-20, 355-20));
+        piecePositions.put("E5", new Point2D(236-20, 132-20));
+        piecePositions.put("E6", new Point2D(236-20, 195-20));
+        piecePositions.put("E7", new Point2D(274-20, 305-20));
+        piecePositions.put("E8", new Point2D(309-20, 355-20));
+        piecePositions.put("E9", new Point2D(119-20, 217-20));
+        piecePositions.put("E10", new Point2D(178-20, 236-20));
+    }
+
+    private void initBoardButtons6() {
+        piecePositions.put("P1", new Point2D(354-20, 370-20)); // 각 x, y의 20만큼 위치 보정
+        piecePositions.put("P2", new Point2D(373-20, 337-20));
+        piecePositions.put("P3", new Point2D(393-20, 303-20));
+        piecePositions.put("P4", new Point2D(409-20, 269-20));
+        piecePositions.put("P5", new Point2D(431-20, 236-20));
+
+        piecePositions.put("P6", new Point2D(409-20, 203-20));
+        piecePositions.put("P7", new Point2D(393-20, 169-20));
+        piecePositions.put("P8", new Point2D(373-20, 133-20));
+        piecePositions.put("P9", new Point2D(354-20, 101-20));
+        piecePositions.put("P10", new Point2D(335-20, 67-20));
+
+        piecePositions.put("P11", new Point2D(295-20, 67-20));
+        piecePositions.put("P12", new Point2D(256-20, 67-20));
+        piecePositions.put("P13", new Point2D(217-20, 67-20));
+        piecePositions.put("P14", new Point2D(178-20, 67-20));
+        piecePositions.put("P15", new Point2D(139-20, 67-20));
+
+        piecePositions.put("P16", new Point2D(118-20, 99-20));
+        piecePositions.put("P17", new Point2D(98-20, 134-20));
+        piecePositions.put("P18", new Point2D(80-20, 168-20));
+        piecePositions.put("P19", new Point2D(60-20, 202-20));
+        piecePositions.put("P20", new Point2D(41-20, 236-20));
+
+        piecePositions.put("P21", new Point2D(60-20, 269-20));
+        piecePositions.put("P22", new Point2D(80-20, 303-20));
+        piecePositions.put("P23", new Point2D(98-20, 337-20));
+        piecePositions.put("P24", new Point2D(118-20, 370-20));
+        piecePositions.put("P25", new Point2D(139-20, 404-20));
+
+        piecePositions.put("P26", new Point2D(178-20, 404-20));
+        piecePositions.put("P27", new Point2D(217-20, 404-20));
+        piecePositions.put("P28", new Point2D(256-20, 404-20));
+        piecePositions.put("P29", new Point2D(295-20, 404-20));
+        piecePositions.put("P30", new Point2D(335-20, 404-20));
+
+        piecePositions.put("C", new Point2D(235-20, 236-20));
+
+        piecePositions.put("E1", new Point2D(366-20, 236-20));
+        piecePositions.put("E2", new Point2D(301-20, 236-20));
+        piecePositions.put("E3", new Point2D(168-20, 236-20));
+        piecePositions.put("E4", new Point2D(105-20, 236-20));
+
+        piecePositions.put("E5", new Point2D(170-20, 123-20));
+        piecePositions.put("E6", new Point2D(203-20, 180-20));
+        piecePositions.put("E7", new Point2D(268-20, 292-20));
+        piecePositions.put("E8", new Point2D(298-20, 348-20));
+
+        piecePositions.put("E9", new Point2D(298-20, 123-20));
+        piecePositions.put("E10", new Point2D(268-20, 180-20));
+        piecePositions.put("E11", new Point2D(203-20, 292-20));
+        piecePositions.put("E12", new Point2D(170-20, 348-20));
+    }
+
+    // ------ Swing: CreateCustomPopupButton을 JavaFX로 변환 ------ //
+    // ------ Custom Popup Button 설정 ------ //
+    private void setupCustomPopupButton() {
+        Image imgUp = new Image(getClass().getResourceAsStream("/data/ui/button/button_custom_up.png"));
+        Image imgDown = new Image(getClass().getResourceAsStream("/data/ui/button/button_custom_down.png"));
+
+        ImageView imageView = new ImageView(imgUp);
+        imageView.setFitWidth(621 / 3.0);
+        imageView.setFitHeight(108 / 3.0);
+
+        Button popupButton = new Button();
+        popupButton.setGraphic(imageView);
+        popupButton.setLayoutX(473);
+        popupButton.setLayoutY(587);
+        popupButton.setStyle("-fx-background-color: transparent;");
+
+        popupButton.setOnMouseEntered(e -> imageView.setImage(imgDown));
+        popupButton.setOnMouseExited(e -> imageView.setImage(imgUp));
+
+        popupButton.setOnAction(e -> openYutPopup());
+
+        root.getChildren().add(popupButton);
+    }
+
+    // ------ Yut Popup 열기 ------ //
+    private void openYutPopup() {
+        int POPUP_WIDTH = 1881 / 3 + 10;
+        int POPUP_HEIGHT = 342 / 3 + 35;
+
+        Stage popupStage = new Stage();
+        popupStage.initOwner(stage);
+        popupStage.setTitle("지정 윷 던지기");
+
+        Pane popupRoot = new Pane();
+        Scene scene = new Scene(popupRoot, POPUP_WIDTH, POPUP_HEIGHT);
+
+        // 배경 이미지
+        Image bgImage = new Image(getClass().getResourceAsStream("/data/ui/custom/custom_steady.png"));
+        BackgroundImage bg = new BackgroundImage(bgImage, BackgroundRepeat.NO_REPEAT, BackgroundRepeat.NO_REPEAT,
+                BackgroundPosition.DEFAULT, new BackgroundSize(POPUP_WIDTH, POPUP_HEIGHT, false, false, false, false));
+        popupRoot.setBackground(new Background(bg));
+
+        // 버튼 생성
+        int BUTTON_WIDTH = POPUP_WIDTH / 6;
+        for (int i = 0; i < 6; i++) {
+            int throwValue = (i == 5) ? -1 : (i + 1);
+            Button yutButton = new Button();
+            yutButton.setLayoutX(BUTTON_WIDTH * i);
+            yutButton.setLayoutY(-20); // 살짝 위로
+            yutButton.setPrefSize(BUTTON_WIDTH, POPUP_HEIGHT);
+            yutButton.setStyle("-fx-background-color: transparent;");
+
+            int finalThrowValue = throwValue;
+            yutButton.setOnAction(e -> {
+                controller.handleManualThrow(finalThrowValue);
+                popupStage.close();
+            });
+
+            popupRoot.getChildren().add(yutButton);
+        }
+
+        popupStage.setScene(scene);
+        popupStage.setResizable(false);
+        popupStage.show();
+    }
+
 
     // ------ show yut result <---- controller ------ //
     public void showYutResult(Integer yutResult) {
+        String imagePath = "/data/ui/yut/yut_" + yutResult + ".png";
+        Image image = new Image(Objects.requireNonNull(getClass().getResourceAsStream(imagePath)));
+
+        double scaledWidth = image.getWidth() / 3;
+        double scaledHeight = image.getHeight() / 3;
+
         if (yutImage == null) {
             yutImage = new ImageView();
-            yutImage.setFitWidth(70);  // 예시 크기 (기존 이미지 크기에 맞게 조절)
-            yutImage.setFitHeight(70);
-            yutImage.setLayoutX(20);   // Swing과 동일하게 좌측 하단 위치
+            yutImage.setLayoutX(20);
             yutImage.setLayoutY(472);
             root.getChildren().add(yutImage);
         }
 
-        String imagePath = "/data/ui/yut/yut_" + yutResult + ".png";
-        Image image = new Image(Objects.requireNonNull(getClass().getResourceAsStream(imagePath)));
         yutImage.setImage(image);
+        yutImage.setFitWidth(scaledWidth);
+        yutImage.setFitHeight(scaledHeight);
+
     }
 
     private void setupYutImage() {
         Image initialImage = new Image(getClass().getResourceAsStream("/data/ui/yut/yut_5.png"));
+        double scaledWidth = initialImage.getWidth() / 3;
+        double scaledHeight = initialImage.getHeight() / 3;
+
         yutImage = new ImageView(initialImage);
-        yutImage.setFitWidth(70);
-        yutImage.setFitHeight(70);
+        yutImage.setFitWidth(scaledWidth);
+        yutImage.setFitHeight(scaledHeight);
         yutImage.setLayoutX(20);
         yutImage.setLayoutY(472);
         root.getChildren().add(yutImage);
@@ -218,24 +522,56 @@ public class JavafxUI implements GameView {
             if (nodeId.equals("START") || nodeId.equals("END")) continue;
 
             // 3. 말 이미지 로드
-            String imagePath = "/data/ui/player/" + pieceId + ".png";
+            String imagePath = "/data/ui/player/p" + pieceId.charAt(0) + "_" + pieceId.length() + ".png";
             Image pieceImage = new Image(Objects.requireNonNull(getClass().getResourceAsStream(imagePath)));
 
             // 4. 말 이미지 뷰 구성
             ImageView pieceView = new ImageView(pieceImage);
-            pieceView.setId("piece_" + pieceId); // 다음 remove 시 식별용
             pieceView.setFitWidth(36);
             pieceView.setFitHeight(36);
+            pieceView.setPreserveRatio(true); // 비율 유지
 
             // 5. 위치 조정 (중앙 정렬)
-            Point2D pos = boardButtonPositions.get(nodeId);
-            pieceView.setLayoutX(pos.getX() - pieceView.getFitWidth() / 2);
-            pieceView.setLayoutY(pos.getY() - pieceView.getFitHeight() / 2);
+            Point2D pos = piecePositions.get(nodeId);
+            pieceView.setLayoutX(pos.getX() - 18); // 36/2
+            pieceView.setLayoutY(pos.getY() - 18);
 
             // 6. 화면에 추가
             root.getChildren().add(pieceView);
         }
+
     }
+
+    private void createThrowButton() {
+        // 1. 이미지 로드
+        Image imgUp = new Image(getClass().getResourceAsStream("/data/ui/button/button_throw_up.png"));
+        Image imgDown = new Image(getClass().getResourceAsStream("/data/ui/button/button_throw_down.png"));
+
+        // 2. 버튼 생성 및 배치
+        throwButton = new Button();
+        ImageView buttonImageView = new ImageView(imgUp);
+        buttonImageView.setFitWidth(imgUp.getWidth() / 3);  // Swing 기준으로 3분의 1 축소
+        buttonImageView.setFitHeight(imgUp.getHeight() / 3);
+
+        throwButton.setGraphic(buttonImageView);
+        throwButton.setLayoutX(473);
+        throwButton.setLayoutY(473);
+        throwButton.setStyle("-fx-background-color: transparent;");
+
+        // 3. Hover 효과
+        throwButton.setOnMouseEntered(e -> buttonImageView.setImage(imgDown));
+        throwButton.setOnMouseExited(e -> buttonImageView.setImage(imgUp));
+
+        // 4. 클릭 이벤트 → 컨트롤러로 던지기 요청
+        throwButton.setOnAction(e -> {
+            controller.handleRandomThrow();
+            System.out.println("Throw Button Clicked");
+        });
+
+        // 5. UI에 추가
+        root.getChildren().add(throwButton);
+    }
+
 
 // ------ updatePlayerScore() ------ //
 public void updatePlayerScore() {
@@ -252,24 +588,68 @@ public void updatePlayerScore() {
     }
 }
 
-    private void setupPlayerScoreImages() {
-        playerScoreImages = new ImageView[numberOfPlayers];
-        for (int i = 0; i < numberOfPlayers; i++) {
-            int playerNum = i + 1;
-            int notStarted = model.getCountOfPieceAtStart()[i];
+    private void createQuitButton() {
+        // 1. 이미지 로드 및 크기 조정
+        Image imgUp = new Image(getClass().getResourceAsStream("/data/ui/button/button_quit_up.png"));
+        Image imgDown = new Image(getClass().getResourceAsStream("/data/ui/button/button_quit_down.png"));
+        // 2. 이미지 뷰 생성
+        ImageView imageView = new ImageView(imgUp);
+        imageView.setFitWidth(279 / 3.0);
+        imageView.setFitHeight(108 / 3.0);
+        // 3. 버튼 생성 및 배치
+        Button quitButton = new Button();
+        quitButton.setGraphic(imageView);
+        quitButton.setLayoutX(584);
+        quitButton.setLayoutY(644);
+        quitButton.setStyle("-fx-background-color: transparent;");
 
-            String imagePath = "/data/ui/score/player" + playerNum + "/player" + playerNum + "_" + notStarted + ".png";
-            Image img = new Image(Objects.requireNonNull(getClass().getResourceAsStream(imagePath)));
+        // Hover 효과
+        quitButton.setOnMouseEntered(e -> imageView.setImage(imgDown));
+        quitButton.setOnMouseExited(e -> imageView.setImage(imgUp));
+        // 4. 클릭 이벤트 → 종료 처리
+        quitButton.setOnAction(e -> {
+            System.out.println("Quit Button Clicked");
+            System.exit(0);
+        });
+        // 5. UI에 추가
+        root.getChildren().add(quitButton);
+    }
 
-            ImageView scoreView = new ImageView(img);
-            scoreView.setFitWidth(80); // 필요 시 조절
-            scoreView.setFitHeight(30);
-            scoreView.setLayoutX(485);
-            scoreView.setLayoutY(181 + 47 * i); // 위치 보정 (Swing 기준)
 
-            root.getChildren().add(scoreView);
-            playerScoreImages[i] = scoreView;
-        }
+    private void createRestartButton() {
+        // 1. 이미지 로드 및 크기 조정
+        Image imgUp = new Image(getClass().getResourceAsStream("/data/ui/button/button_restart_up.png"));
+        Image imgDown = new Image(getClass().getResourceAsStream("/data/ui/button/button_restart_down.png"));
+        // 2. 이미지 뷰 생성
+        ImageView imageView = new ImageView(imgUp);
+        imageView.setFitWidth(imgUp.getWidth() / 3);
+        imageView.setFitHeight(imgUp.getHeight() / 3);
+        // 3. 버튼 생성 및 배치
+        Button restartButton = new Button();
+        restartButton.setGraphic(imageView);
+        restartButton.setLayoutX(473);
+        restartButton.setLayoutY(644);
+        restartButton.setStyle("-fx-background-color: transparent;");
+
+        // Hover 효과
+        restartButton.setOnMouseEntered(e -> imageView.setImage(imgDown));
+        restartButton.setOnMouseExited(e -> imageView.setImage(imgUp));
+        // 4. 클릭 이벤트 → 새 게임 시작
+        restartButton.setOnAction(e -> {
+            System.out.println("Restart Button Clicked");
+            // 새 게임 모델과 컨트롤러, 뷰 생성
+            GameManager newModel = new GameManager();
+            GameController newController = new GameController(newModel);
+            JavafxUI newView = new JavafxUI(newController, newModel);
+            newController.setView(newView);
+
+            // 새 게임 시작
+            stage.close(); // 현재 창 닫고
+            Stage newStage = new Stage();
+            newView.start(newStage); // 새 게임 시작
+        });
+        // 5. UI에 추가
+        root.getChildren().add(restartButton);
     }
 
     // ------ updateTurn() ------ //
@@ -281,19 +661,7 @@ public void updatePlayerScore() {
         turnImage.setImage(img);
     }
 
-    private void setupTurnImage() {
-        int currentPlayer = model.getCurrentPlayerNumber(); // 보통 1부터 시작
-        String imagePath = "/data/ui/turn/turn_" + currentPlayer + ".png";
-        Image img = new Image(Objects.requireNonNull(getClass().getResourceAsStream(imagePath)));
 
-        turnImage = new ImageView(img);
-        turnImage.setFitWidth(90);  // 예시 크기 (조절 가능)
-        turnImage.setFitHeight(30);
-        turnImage.setLayoutX(485);  // Swing 기준 보정값
-        turnImage.setLayoutY(392);
-
-        root.getChildren().add(turnImage);
-    }
 }
 
 


### PR DESCRIPTION
## 📌 개요 (Summary)

JavaFX 버전의 윷놀이 UI완성 및 config 파일에 따라 javaFX UI 실행 엔트리포인트 구현

## 🔍 변경 사항 (Changes)

- [ ] feat:
    -  `view.JavafxUI`: JavaFX 기반 전체 UI 구성 및 요소별 구현 (배경, 버튼, 점수판, 윷 결과 등)
    - `view.JavaFXLauncher`: config 파일에 따라 JavaFX UI 실행 엔트리포인트 구성
- [ ] fix:
    - main 파일에서 config 파일 data를 받아와 어떤 UI로 실행할 것인지에 대한 조건 분기
- [ ] refactor:
    - `refactor` commit list



## 🧪 테스트 결과 (Test Results)

    - 로컬 테스트 완료: JavaFX 실행 성공, 하지만 말을 보드에 올릴 때의 좌표값이 조금 다름 -> 수정필요]
    - Swing <-> JavaFX 선택적 실행 확인
    - 턴 처리, 윷 결과, 말 이동 등 게임 흐름 정상 작동


## 🙋 기타 공유사항

말을 보드 위에 올려놓을 때의 좌표가 왼쪽으로 쏠려있어 이 부분에 대한 수정 필요함 (빠르게 해결 가능 하지만 너무 졸려서 자고 일어나서 수정해놓겠습니다아...)
